### PR TITLE
Issue 36

### DIFF
--- a/pages/profile.jsx
+++ b/pages/profile.jsx
@@ -157,7 +157,18 @@ const Profile = () => {
                 </div>
                 <div className="profile-row bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200">
                   <dt className="font-mediu">Role</dt>
-                  <dd className="mt-1 sm:col-span-2 sm:mt-0">{data.role}</dd>
+                  <dd className="mt-1 sm:col-span-2 sm:mt-0">
+                    {data.role === 'predental' ? (
+                      'Pre-Dental'
+                    ) : data.role === 'da1' ? (
+                      'Dental Assistant One'
+                    ) : data.role === 'da2' ? (
+                      'Dental Assistant Two'
+                    ) : data.role === 'rdh' ? (
+                      'Registered Dental Hygienist'
+                    ) : (
+                      'Dentist'
+                    )}</dd>
                 </div>
                 <div className="profile-row bg-white dark:bg-neutral-900 dark:text-neutral-200">
                   <dt className="font-mediu flex flex-start">

--- a/pages/profile.jsx
+++ b/pages/profile.jsx
@@ -158,13 +158,13 @@ const Profile = () => {
                 <div className="profile-row bg-gray-50 dark:bg-neutral-800 dark:text-neutral-200">
                   <dt className="font-mediu">Role</dt>
                   <dd className="mt-1 sm:col-span-2 sm:mt-0">
-                    {data.role === 'predental' ? (
+                    {data.role === 'Pre-Dental' ? (
                       'Pre-Dental'
-                    ) : data.role === 'da1' ? (
+                    ) : data.role === 'Dental Assistant One' ? (
                       'Dental Assistant One'
-                    ) : data.role === 'da2' ? (
+                    ) : data.role === 'Dental Assistant Two' ? (
                       'Dental Assistant Two'
-                    ) : data.role === 'rdh' ? (
+                    ) : data.role === 'Registered Dental Hygienist' ? (
                       'Registered Dental Hygienist'
                     ) : (
                       'Dentist'

--- a/pages/registration.jsx
+++ b/pages/registration.jsx
@@ -275,11 +275,11 @@ const Registration = () => {
                     required
                   >
                     <option value="">Choose a role</option>
-                    <option  value="predental">Pre-Dental</option>
-                    <option  value="da1">Dental Assistant One</option>
-                    <option  value="da2">Dental Assistant Two</option>
-                    <option  value="rdh">Registered Dental Hygienist</option>
-                    <option  value="dentist">Dentist</option>
+                    <option  value="Pre-Dental">Pre-Dental</option>
+                    <option  value="Dental Assistant One">Dental Assistant One</option>
+                    <option  value="Dental Assistant Two">Dental Assistant Two</option>
+                    <option  value="Registered Dental Hygienist">Registered Dental Hygienist</option>
+                    <option  value="Dentist">Dentist</option>
                   </select>
                 </div>
 

--- a/pages/registration.jsx
+++ b/pages/registration.jsx
@@ -22,6 +22,7 @@ const Registration = () => {
   const cityRef = useRef("");
   const stateRef = useRef("");
   const zipRef = useRef("");
+  const roleRef = useRef("");
   const waiverRef = useRef(false);
   const hipaaRef = useRef(false);
 
@@ -57,7 +58,7 @@ const Registration = () => {
             first_name: fnameRef.current.value,
             last_name: lnameRef.current.value,
             dob: currentDob,
-            role: "pre-dental",
+            role: roleRef.current.value,
             phone: phoneVal,
             address: addressRef.current.value,
             city: cityRef.current.value,
@@ -261,6 +262,27 @@ const Registration = () => {
                     required
                   />
                 </div>
+
+                <div className="col-span-3">
+                  <label htmlFor="role" className="auth-label">
+                    Role
+                  </label>
+                  <select
+                   // ref={roleRef}
+                    name="role"
+                    className="auth-input"
+                    ref={roleRef}
+                    required
+                  >
+                    <option value="">Choose a role</option>
+                    <option  value="predental">Pre-Dental</option>
+                    <option  value="da1">Dental Assistant One</option>
+                    <option  value="da2">Dental Assistant Two</option>
+                    <option  value="rdh">Registered Dental Hygienist</option>
+                    <option  value="dentist">Dentist</option>
+                  </select>
+                </div>
+
               </div>
               <hr className="mt-5 mb-5 dark:border-neutral-600" />
               <fieldset>

--- a/pages/shifts.jsx
+++ b/pages/shifts.jsx
@@ -29,12 +29,17 @@ const Shifts = () => {
           // Get user information
           await supabase
             .from("profiles")
-            .select("id, first_name, last_name, email, orientation")
+            .select("id, first_name, last_name, email, orientation, role")
             .eq("id", id)
             .then(async ({ data }) => {
               if (data && data.length > 0) {
-                const sType = data[0].orientation ? "volunteer" : "orientation";
                 const uid = data[0].id;
+                let sType 
+                if (data[0].orientation) {
+                  sType = data[0].role.toLowerCase();
+                } else {
+                  sType = "orientation";
+                }
 
                 setUser(data[0]);
                 setShiftType(sType.charAt(0).toUpperCase() + sType.slice(1));
@@ -188,7 +193,7 @@ const Shifts = () => {
         <div className="container p-10">
           <div className="shadow sm:rounded-lg border-transparent w-4/5 dark:bg-neutral-900 dark:border-2 dark:border-neutral-800">
             <div className="px-4 py-5 sm:px-6">
-              <h2>Available {shiftType} Shifts</h2>
+              <h2>Available {shiftType.replace(/\b\w/g, (match) => match.toUpperCase())} Shifts</h2>
             </div>
 
             <div className="border-t border-gray-200 p-4 dark:border-neutral-800">
@@ -266,7 +271,7 @@ const Shifts = () => {
                       <button
                         type="button"
                         className="indigo-button-lg"
-                        onClick={() => setOpen(false)}
+                        onClick={() => location.reload()}
                       >
                         OK
                       </button>


### PR DESCRIPTION
When signing up users can now select a role
Users can only see shifts that are of their specific role type
Fixed a bug where if an existing shift is edited on the admin side then it goes away on the users side
Fixed an issue where someone could signup for the same shift and it floods their schedule page by forcing a refresh after every sign up.