### PR TITLE
As a Pre-Dental student I should only see available orientations shifts until I am oriented so that I am fully prepared for my first shift.

### DIFF
--- a/pages/registration.jsx
+++ b/pages/registration.jsx
@@ -64,7 +64,7 @@ const Registration = () => {
             city: cityRef.current.value,
             state: stateRef.current.value,
             zip: zipRef.current.value,
-            orientation: false,
+            orientation: (roleRef.current.value == "Pre-Dental") ? false : true,
           },
         },
       })

--- a/pages/registration.jsx
+++ b/pages/registration.jsx
@@ -64,7 +64,7 @@ const Registration = () => {
             city: cityRef.current.value,
             state: stateRef.current.value,
             zip: zipRef.current.value,
-            orientation: (roleRef.current.value == "Pre-Dental") ? false : true,
+            orientation: (roleRef.current.value == "Dentist" || roleRef.current.value == "Registered Dental Hygienist")
           },
         },
       })


### PR DESCRIPTION
Now only pre-dental students need to do orientation. Any other role will have orientation
set to true upon registration!